### PR TITLE
Fix stylesheet imports

### DIFF
--- a/frontend/src/components/InfoComponent.js
+++ b/frontend/src/components/InfoComponent.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import './styles.css';
+// Import component specific styles
+import './styles/styles.css';
 
 const InfoComponent = () => {
   const updateValue = (el) => {

--- a/frontend/src/components/MapComponent.js
+++ b/frontend/src/components/MapComponent.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import L from 'leaflet';
-import './styles.css';
+// Import map layout styles
+import './styles/styles.css';
 
 const MapComponent = ({ setMap }) => {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix CSS import paths for InfoComponent and MapComponent

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcc9f0988325987422247c968b79