### PR TITLE
Import Leaflet CSS

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import 'leaflet/dist/leaflet.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 


### PR DESCRIPTION
## Summary
- fix CSS import so Leaflet map tiles align properly

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f078f670c8325a1f8d2b28d109fcc